### PR TITLE
Change the way to save custom variables.

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -101,8 +101,7 @@ Suggested possible values are:
 
 (defun helm-dash-activate-docset (docset)
   (add-to-list 'helm-dash-active-docsets docset)
-  (custom-set-variables `(helm-dash-active-docsets ,helm-dash-active-docsets t))
-  (custom-save-all))
+  (customize-save-variable 'helm-dash-active-docsets helm-dash-active-docsets))
 
 (defun helm-dash-install-docset ()
   "Download docset with specified NAME and move its stuff to docsets-path."


### PR DESCRIPTION
I changed custom-set-variables&&custom-save-all by
customize-save-variable. I guess that is the standard way and with the
custom-set-variables I received this error message:

"Error setting helm-dash-active-docsets: (invalid-function Ansible)"
