### PR TITLE
Add autoload-cookie to helm-dash-install-docset

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -104,6 +104,7 @@ Suggested possible values are:
   (add-to-list 'helm-dash-active-docsets docset)
   (customize-save-variable 'helm-dash-active-docsets helm-dash-active-docsets))
 
+;;;###autoload
 (defun helm-dash-install-docset ()
   "Download docset with specified NAME and move its stuff to docsets-path."
   (interactive)


### PR DESCRIPTION
The autoload cookie is necessary so we can execute `helm-dash-install-docset` without explicitly requiring the library
