### PR TITLE
Fix opening docs in eww in Windows

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -313,7 +313,7 @@ Sanitization of spaces in the path."
      " "
      "%20"
      (format "%s%s%s%s"
-	     "file://"
+	     "file:///"
 	     helm-dash-docsets-path
 	     (format "/%s.docset/Contents/Resources/Documents/" docset-name)
 	     path))))


### PR DESCRIPTION
With the `file://` prefix, eww thinks that you're trying to open an FTP connection. However, with `file:///` (note the additional slash), everything works fine.

I haven't tested this on other platforms; it would be wise to check that out.
