### PR TITLE
Allow full HTTP URLs.

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -301,17 +301,20 @@ Ex: This avoids searching for redis in redis unless you type 'redis redis'"
     full-res))
 
 (defun helm-dash-result-url (docset-name filename &optional anchor)
-  "Return the absolute path joining docsets path, DOCSET-NAME,FILENAME & ANCHOR.
-Sanitization of spaces in the path."
+  "Return the full, absolute URL to documentation: either a file:// URL joining
+DOCSET-NAME, FILENAME & ANCHOR with sanitization of spaces or a http(s):// URL
+formed as-is if FILENAME is a full HTTP(S) URL."
   (let ((path (format "%s%s" filename (if anchor (format "#%s" anchor) ""))))
-    (replace-regexp-in-string
-     " "
-     "%20"
-     (format "%s%s%s%s"
-	     "file:///"
-	     helm-dash-docsets-path
-	     (format "/%s.docset/Contents/Resources/Documents/" docset-name)
-	     path))))
+    (if (string-match-p "^https?://" path)
+        path
+      (replace-regexp-in-string
+       " "
+       "%20"
+       (format "%s%s%s%s"
+               "file:///"
+               helm-dash-docsets-path
+               (format "/%s.docset/Contents/Resources/Documents/" docset-name)
+               path)))))
 
 (defun helm-dash-browse-url (search-result)
   "Call to `browse-url' with the result returned by `helm-dash-result-url'.


### PR DESCRIPTION
If the docset datebase contains full, absolute HTTP(S) URLs instead of
relative paths and achors to local files, open those URLs as-is.
