### PR TITLE
Improve the narrowing of docsets.

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -271,7 +271,7 @@ If PATTERN starts with the name of a docset followed by a space, narrow the
   (let ((connections (helm-dash-filter-connections))
         (f-word (car (split-string pattern " "))))
     (or
-     (remove-if-not (lambda (x) (string-match f-word (car x)))
+     (cl-remove-if-not (lambda (x) (string-match f-word (car x)))
               connections)
      connections)))
 

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -263,32 +263,32 @@ The Argument FEED-PATH should be a string with the path of the xml file."
   ""
   (funcall (cdr (assoc query-type (assoc (intern docset-type) helm-dash-sql-queries))) pattern))
 
-(defun helm-dash-maybe-narrow-to-one-docset (pattern)
+(defun helm-dash-maybe-narrow-docsets (pattern)
   "Return a list of helm-dash-connections.
 If PATTERN starts with the name of a docset followed by a space, narrow the
  used connections to just that one.  We're looping on all connections, but it
  shouldn't be a problem as there won't be many."
-  (let ((conns (helm-dash-filter-connections)))
-    (or (cl-loop for x in conns
-                 if (string-prefix-p
-                     (concat (downcase (car x)) " ")
-                     (downcase pattern))
-                 return (list x))
-        conns)))
+  (let ((connections (helm-dash-filter-connections))
+        (f-word (car (split-string pattern " "))))
+    (or
+     (remove-if-not (lambda (x) (string-match f-word (car x)))
+              connections)
+     connections)))
 
 (defun helm-dash-sub-docset-name-in-pattern (pattern docset-name)
   "Remove from PATTERN the DOCSET-NAME if this includes it.
 If the search starts with the name of the docset, ignore it.
 Ex: This avoids searching for redis in redis unless you type 'redis redis'"
-  (replace-regexp-in-string
-   (format "^%s " (regexp-quote (downcase docset-name)))
-   ""
-   pattern))
+  (let ((f-word (car (split-string pattern " "))))
+    (if (string-match f-word docset-name)
+        (replace-regexp-in-string
+         (format "^%s " (regexp-quote f-word)) "" pattern)
+        pattern)))
 
 (defun helm-dash-search ()
   "Iterates every `helm-dash-connections' looking for the `helm-pattern'."
   (let ((full-res (list))
-        (connections (helm-dash-maybe-narrow-to-one-docset helm-pattern)))
+        (connections (helm-dash-maybe-narrow-docsets helm-pattern)))
 
     (dolist (docset connections)
       (let* ((docset-type (cl-caddr docset))

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -274,7 +274,7 @@ If PATTERN starts with the name of a docset followed by a space, narrow the
      (and (> (length splitted-pat) 1)
       (cl-remove-if-not (lambda (con)
                           (cl-every (lambda (word)
-                                      (string-match word (car con)))
+                                      (string-match (regexp-quote word) (car con)))
                                     (split-string (car splitted-pat) " ")))
                         connections))
      connections)))

--- a/test/helm-dash-test.el
+++ b/test/helm-dash-test.el
@@ -25,9 +25,9 @@
 
 ;;; Code:
 
-;;;; helm-dash-maybe-narrow-to-one-docset
+;;;; helm-dash-maybe-narrow-docsets
 
-(ert-deftest helm-dash-maybe-narrow-to-one-docset-test/filtered ()
+(ert-deftest helm-dash-maybe-narrow-docsets-test/filtered ()
   "Should return a list with filtered connections."
   (let ((pattern "Go ")
         (helm-dash-docsets-path "/tmp/.docsets")
@@ -38,14 +38,14 @@
            ("C" "/tmp/.docsets/C.docset/Contents/Resources/docSet.dsidx" "DASH")
            ("C++" "/tmp/.docsets/C++.docset/Contents/Resources/docSet.dsidx" "DASH")
            ("CSS" "/tmp/.docsets/CSS.docset/Contents/Resources/docSet.dsidx" "ZDASH"))))
-    (should (equal (helm-dash-maybe-narrow-to-one-docset pattern)
+    (should (equal (helm-dash-maybe-narrow-docsets pattern)
                    '(("Go" "/tmp/.docsets/Go.docset/Contents/Resources/docSet.dsidx" "DASH"))))
 
-    (should (equal "C" (caar (helm-dash-maybe-narrow-to-one-docset "C foo"))))
-    (should (equal "C++" (caar (helm-dash-maybe-narrow-to-one-docset "C++ foo"))))
-    (should (equal "C" (caar (helm-dash-maybe-narrow-to-one-docset "c foo"))))))
+    (should (equal "C" (caar (helm-dash-maybe-narrow-docsets "C foo"))))
+    (should (equal "C++" (caar (helm-dash-maybe-narrow-docsets "C++ foo"))))
+    (should (equal "C" (caar (helm-dash-maybe-narrow-docsets "c foo"))))))
 
-(ert-deftest helm-dash-maybe-narrow-to-one-docset-test/not-filtered ()
+(ert-deftest helm-dash-maybe-narrow-docsets-test/not-filtered ()
   "Should return all current connections because the pattern doesn't match with any connection."
   (let ((pattern "FOOOO ")
 	(helm-dash-docsets-path "/tmp/.docsets")
@@ -54,7 +54,7 @@
 	 '(("Redis" "/tmp/.docsets/Redis.docset/Contents/Resources/docSet.dsidx" "DASH")
 	   ("Go" "/tmp/.docsets/Go.docset/Contents/Resources/docSet.dsidx" "DASH")
 	   ("CSS" "/tmp/.docsets/CSS.docset/Contents/Resources/docSet.dsidx" "ZDASH"))))
-    (should (equal (helm-dash-maybe-narrow-to-one-docset pattern) helm-dash-connections))))
+    (should (equal (helm-dash-maybe-narrow-docsets pattern) helm-dash-connections))))
 
 
 ;;;; helm-dash-sub-docset-name-in-pattern

--- a/test/helm-dash-test.el
+++ b/test/helm-dash-test.el
@@ -29,7 +29,7 @@
 
 (ert-deftest helm-dash-maybe-narrow-docsets-test/filtered ()
   "Should return a list with filtered connections."
-  (let ((pattern "Go ")
+  (let ((pattern "Go | ")
         (helm-dash-docsets-path "/tmp/.docsets")
         (helm-dash-common-docsets '("Redis" "Go" "CSS" "C" "C++"))
         (helm-dash-connections
@@ -41,13 +41,17 @@
     (should (equal (helm-dash-maybe-narrow-docsets pattern)
                    '(("Go" "/tmp/.docsets/Go.docset/Contents/Resources/docSet.dsidx" "DASH"))))
 
-    (should (equal "C" (caar (helm-dash-maybe-narrow-docsets "C foo"))))
-    (should (equal "C++" (caar (helm-dash-maybe-narrow-docsets "C++ foo"))))
-    (should (equal "C" (caar (helm-dash-maybe-narrow-docsets "c foo"))))))
+    (should (equal "C++" (caar (helm-dash-maybe-narrow-docsets "C++ | foo"))))
+
+    ;; Caveat, but as we match substrings, when looking for 'c', we'll
+    ;; match CSS and C++. It's a corner case, as most have more and
+    ;; unique digraphs.
+    (should (equal 3 (length (helm-dash-maybe-narrow-docsets "C | foo"))))
+    (should (equal 3 (length (helm-dash-maybe-narrow-docsets "c | foo"))))))
 
 (ert-deftest helm-dash-maybe-narrow-docsets-test/not-filtered ()
-  "Should return all current connections because the pattern doesn't match with any connection."
-  (let ((pattern "FOOOO ")
+  "Should return no connections because the pattern doesn't match with any connection."
+  (let ((pattern "FOOOO | lal")
 	(helm-dash-docsets-path "/tmp/.docsets")
 	(helm-dash-common-docsets '("Redis" "Go" "CSS"))
 	(helm-dash-connections
@@ -61,9 +65,9 @@
 
 (ert-deftest helm-dash-sub-docset-name-in-pattern-test/with-docset-name ()
   ""
-  (let ((pattern "Redis BLPOP")
+  (let ((pattern "Redis | BLPOP")
 	(docset "Redis"))
-    (should (equal (helm-dash-sub-docset-name-in-pattern pattern docset) "BLPOP"))))
+    (should (equal (helm-dash-sub-docset-name-in-pattern pattern docset) " BLPOP"))))
 
 (ert-deftest helm-dash-sub-docset-name-in-pattern-test/without-docset-name ()
   ""
@@ -73,9 +77,9 @@
 
 (ert-deftest helm-dash-sub-docset-name-in-pattern-test/with-special-docset-name ()
   ""
-  (let ((pattern "C++ printf")
+  (let ((pattern "C++ | printf")
 	(docset "C++"))
-    (should (equal (helm-dash-sub-docset-name-in-pattern pattern docset) "printf"))))
+    (should (equal (helm-dash-sub-docset-name-in-pattern pattern docset) " printf"))))
 
 
 ;;;; helm-dash-result-url


### PR DESCRIPTION
The first word of the search pattern will filter docsets. Only one word
will act as a docset filter.  If the first word matches all or part of a
docset, this docset will be searched. the search will be done of all but
the first word.