### PR TITLE
Increase max number of results

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -246,11 +246,11 @@ The Argument FEED-PATH should be a string with the path of the xml file."
 (defvar helm-dash-sql-queries
   '((DASH . ((select . (lambda (pattern)
                          (let ((like (helm-dash-sql-compose-like "t.name" pattern))
-                               (query "SELECT t.type, t.name, t.path FROM searchIndex t WHERE %s ORDER BY LOWER(t.name) LIMIT 100"))
+                               (query "SELECT t.type, t.name, t.path FROM searchIndex t WHERE %s ORDER BY LOWER(t.name) LIMIT 1000"))
                            (format query like))))))
     (ZDASH . ((select . (lambda (pattern)
                           (let ((like (helm-dash-sql-compose-like "t.ZTOKENNAME" pattern))
-                                (query "SELECT ty.ZTYPENAME, t.ZTOKENNAME, f.ZPATH, m.ZANCHOR FROM ZTOKEN t, ZTOKENTYPE ty, ZFILEPATH f, ZTOKENMETAINFORMATION m WHERE ty.Z_PK = t.ZTOKENTYPE AND f.Z_PK = m.ZFILE AND m.ZTOKEN = t.Z_PK AND %s ORDER BY LOWER(t.ZTOKENNAME) LIMIT 100"))
+                                (query "SELECT ty.ZTYPENAME, t.ZTOKENNAME, f.ZPATH, m.ZANCHOR FROM ZTOKEN t, ZTOKENTYPE ty, ZFILEPATH f, ZTOKENMETAINFORMATION m WHERE ty.Z_PK = t.ZTOKENTYPE AND f.Z_PK = m.ZFILE AND m.ZTOKEN = t.Z_PK AND %s ORDER BY LOWER(t.ZTOKENNAME) LIMIT 1000"))
                             (format query like))))))))
 
 (defun helm-dash-sql-compose-like (column pattern)
@@ -354,7 +354,8 @@ Get required params to call `helm-dash-result-url' from SEARCH-RESULT."
   (helm-dash-create-common-connections)
   (helm-dash-create-buffer-connections)
   (helm :sources (list (helm-source-dash-search))
-	:buffer "*helm-dash*"))
+        :buffer "*helm-dash*"
+        :helm-candidate-number-limit 1000))
 
 ;;;###autoload
 (defun helm-dash-at-point ()
@@ -365,7 +366,8 @@ point as prefilled search."
   (helm-dash-create-buffer-connections)
   (helm :sources (list (helm-source-dash-search))
 	:buffer "*helm-dash*"
-	:input (thing-at-point 'symbol)))
+	:input (thing-at-point 'symbol)
+  :helm-candidate-number-limit 1000))
 
 (provide 'helm-dash)
 


### PR DESCRIPTION
1000 is saner than 100. 

Especially when looking for very general things like 'read'