### PR TITLE
Support spaces in helm-dash-docsets-path

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -220,7 +220,7 @@ Report an error unless a valid docset is selected."
       (mkdir docset-path t))
     (let ((docset-folder
 	   (helm-dash-docset-folder-name
-	    (shell-command-to-string (format "tar xvf %s -C %s" docset-tmp-path (helm-dash-docsets-path))))))
+	    (shell-command-to-string (format "tar xvf %s -C %s" docset-tmp-path (shell-quote-argument helm-dash-docsets-path))))))
       (helm-dash-activate-docset docset-folder)
       (message (format
 		"Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."


### PR DESCRIPTION
By default, the Dash app installs docsets in ~/Library/Application Support/Dash/Docsets

When helm-dash-docsets-path has spaces in it, tar command fails on Mac OS X.

To handle that, I suggest adding shell-quote-argument around it.  Tested in Emacs 24.4.1 on Mac OS X 10.3