### PR TITLE
User docsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ there is an explanation about stable packages and MELPA and
 
 `m-x package-install helm-dash RET`
 
+
+## Installing docsets
+
+Helm-dash uses the same docsets as [Dash](http://www.kapeli.com/dash).
+You can install them with `m-x helm-dash-install-docset` for the
+official docsets or `m-x helm-dash-install-user-docset` for user
+contributed docsets (experimental).
+
 ## Usage
 
 `m-x helm-dash RET` will run helm with your active docsets

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ You can install them with `m-x helm-dash-install-docset` for the
 official docsets or `m-x helm-dash-install-user-docset` for user
 contributed docsets (experimental).
 
+To install a docset from a file in your drive you can use `m-x
+helm-dash-install-docset-from-file'.
+
 ## Usage
 
 `m-x helm-dash RET` will run helm with your active docsets

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -271,7 +271,7 @@ If PATTERN starts with the name of a docset followed by a space, narrow the
   (let ((connections (helm-dash-filter-connections))
         (f-word (car (split-string pattern " "))))
     (or
-     (remove-if-not (lambda (x) (string-match f-word (car x)))
+     (cl-remove-if-not (lambda (x) (string-match f-word (car x)))
               connections)
      connections)))
 

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -152,13 +152,28 @@ The Argument DB-PATH should be a string with the sqlite db path."
 	"DASH"
       "ZDASH")))
 
-(defun helm-dash-search-all-docsets ()
-  "Fetch docsets from the original Kapeli's feed."
-  (let ((url "https://api.github.com/repos/Kapeli/feeds/contents/"))
+
+(defun helm-dash-read-json-from-url (addr)
+  (let ((url addr))
     (with-current-buffer
         (url-retrieve-synchronously url)
       (goto-char url-http-end-of-headers)
       (json-read))))
+
+(defun helm-dash-search-all-docsets ()
+  "Fetch docsets from the original Kapeli's feed."
+  (let ((url "https://api.github.com/repos/Kapeli/feeds/contents/"))
+    (helm-dash-read-json-from-url url)))
+
+(defun helm-dash-search-all-user-docsets ()
+  (let ((user-docs (helm-dash-read-json-from-url
+                    ;"http://sanfrancisco.kapeli.com/feeds/zzz/user_contributed/build/index.json"
+                    "https://dashes-to-dashes.herokuapp.com/contrib-docs"
+                    )))
+    (mapcar (lambda (docset)
+              (assoc-default 'archive (cdr docset))
+              (assoc-default 'name (cdr docset)))
+            user-docs)))
 
 (defvar helm-dash-ignored-docsets
   '("Bootstrap" "Drupal" "Zend_Framework" "Ruby_Installed_Gems" "Man_Pages")

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -246,7 +246,7 @@ Report an error unless a valid docset is selected."
   (let ((docset-folder
          (helm-dash-docset-folder-name
           (shell-command-to-string
-           (format "tar xvf %s -C %s" docset-tmp-path (helm-dash-docsets-path))))))
+           (format "tar xvf %s -C %s" (shell-quote-argument docset-tmp-path) (helm-dash-docsets-path))))))
     (helm-dash-activate-docset docset-folder)
     (message (format
               "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -174,8 +174,9 @@ The Argument DB-PATH should be a string with the sqlite db path."
                     "https://dashes-to-dashes.herokuapp.com/contrib-docs"
                     )))
     (mapcar (lambda (docset)
-              (assoc-default 'archive (cdr docset))
-              (assoc-default 'name (cdr docset)))
+              (list
+               (assoc-default 'name docset)
+               (assoc-default 'archive docset)))
             user-docs)))
 
 (defvar helm-dash-ignored-docsets
@@ -220,8 +221,8 @@ Report an error unless a valid docset is selected."
   (helm-dash-reset-connections))
 
 (defun helm-dash--install-docset (url docset-name)
-  (let ((docset-tmp-path (format "%s%s-docset.tgz" temporary-file-directory docset-name))
-        (url-copy-file url (helm-dash-docsets-path) t))
+  (let ((docset-tmp-path (format "%s%s-docset.tgz" temporary-file-directory docset-name)))
+    (url-copy-file url docset-tmp-path t)
     (helm-dash--unpack docset-tmp-path (helm-dash-docsets-path))))
 
 
@@ -240,6 +241,16 @@ Report an error unless a valid docset is selected."
     (message (format
               "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."
               docset-folder))))
+
+
+;;;###autoload
+(defun helm-dash-install-user-docset (docset-name)
+  (interactive (list (helm-dash-read-docset
+                      "Install docset"
+                      (mapcar 'car (helm-dash-search-all-user-docsets)))))
+  (when (helm-dash--ensure-created-docsets-path (helm-dash-docsets-path))
+    (helm-dash--install-docset (car (assoc-default docset-name (helm-dash-search-all-user-docsets))) docset-name)))
+
 
 ;;;###autoload
 (defun helm-dash-install-docset (docset-name)

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -309,22 +309,22 @@ The Argument FEED-PATH should be a string with the path of the xml file."
 If PATTERN starts with the name of a docset followed by a space, narrow the
  used connections to just that one.  We're looping on all connections, but it
  shouldn't be a problem as there won't be many."
-  (let ((connections (helm-dash-filter-connections))
-        (f-word (car (split-string pattern " "))))
-    (or
-     (cl-remove-if-not (lambda (x) (string-match f-word (car x)))
-              connections)
-     connections)))
+  (let ((conns (helm-dash-filter-connections)))
+    (or (cl-loop for x in conns
+                 if (string-prefix-p
+                     (concat (downcase (car x)) " ")
+                     (downcase pattern))
+                 return (list x))
+        conns)))
 
 (defun helm-dash-sub-docset-name-in-pattern (pattern docset-name)
   "Remove from PATTERN the DOCSET-NAME if this includes it.
 If the search starts with the name of the docset, ignore it.
 Ex: This avoids searching for redis in redis unless you type 'redis redis'"
-  (let ((f-word (car (split-string pattern " "))))
-    (if (string-match f-word docset-name)
-        (replace-regexp-in-string
-         (format "^%s " (regexp-quote f-word)) "" pattern)
-        pattern)))
+  (replace-regexp-in-string
+   (format "^%s " (regexp-quote (downcase docset-name)))
+   ""
+   pattern))
 
 (defun helm-dash-search ()
   "Iterates every `helm-dash-connections' looking for the `helm-pattern'."

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -221,24 +221,13 @@ Report an error unless a valid docset is selected."
 (defun helm-dash--install-docset (url docset-name)
   (let ((docset-tmp-path (format "%s%s-docset.tgz" temporary-file-directory docset-name)))
     (url-copy-file url docset-tmp-path t)
-    (helm-dash--unpack docset-tmp-path (helm-dash-docsets-path))))
-
+    (helm-dash-install-docset-from-file docset-tmp-path)))
 
 (defun helm-dash--ensure-created-docsets-path (docset-path)
   (or (file-directory-p docset-path)
       (and (y-or-n-p (format "Directory %s does not exist.  Want to create it? "
                              docset-path))
            (mkdir docset-path t))))
-
-
-(defun helm-dash--unpack (docset-tmp-path destination-path)
-  (let ((docset-folder
-         (helm-dash-docset-folder-name
-          (shell-command-to-string (format "tar xvf %s -C %s" docset-tmp-path (helm-dash-docsets-path))))))
-    (helm-dash-activate-docset docset-folder)
-    (message (format
-              "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."
-              docset-folder))))
 
 
 ;;;###autoload
@@ -249,6 +238,19 @@ Report an error unless a valid docset is selected."
   (when (helm-dash--ensure-created-docsets-path (helm-dash-docsets-path))
     (helm-dash--install-docset (car (assoc-default docset-name (helm-dash-search-all-user-docsets))) docset-name)))
 
+
+;;;###autoload
+(defun helm-dash-install-docset-from-file (docset-tmp-path)
+  (interactive
+   (list (car (find-file-read-args "Docset Tarball: " t))))
+  (let ((docset-folder
+         (helm-dash-docset-folder-name
+          (shell-command-to-string
+           (format "tar xvf %s -C %s" docset-tmp-path (helm-dash-docsets-path))))))
+    (helm-dash-activate-docset docset-folder)
+    (message (format
+              "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."
+              docset-folder))))
 
 ;;;###autoload
 (defun helm-dash-install-docset (docset-name)
@@ -265,7 +267,7 @@ Report an error unless a valid docset is selected."
     (url-copy-file feed-url feed-tmp-path t)
     (url-copy-file (helm-dash-get-docset-url feed-tmp-path) docset-tmp-path t)
 
-    (helm-dash--unpack docset-tmp-path (helm-dash-docsets-path)))))
+    (helm-dash-install-docset-from-file docset-tmp-path))))
 
 (defalias 'helm-dash-update-docset 'helm-dash-install-docset)
 

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -6,7 +6,7 @@
 ;;         Toni Reina  <areina0@gmail.com>
 ;;
 ;; URL: http://github.com/areina/helm-dash
-;; Version: 1.1
+;; Version: 1.2.1
 ;; Package-Requires: ((helm "0.0.0") (cl-lib "0.5"))
 ;; Keywords: docs
 

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -170,9 +170,7 @@ The Argument DB-PATH should be a string with the sqlite db path."
 
 (defun helm-dash-search-all-user-docsets ()
   (let ((user-docs (helm-dash-read-json-from-url
-                    ;"http://sanfrancisco.kapeli.com/feeds/zzz/user_contributed/build/index.json"
-                    "https://dashes-to-dashes.herokuapp.com/contrib-docs"
-                    )))
+                    "https://dashes-to-dashes.herokuapp.com/docsets/contrib")))
     (mapcar (lambda (docset)
               (list
                (assoc-default 'name docset)

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -263,32 +263,32 @@ The Argument FEED-PATH should be a string with the path of the xml file."
   ""
   (funcall (cdr (assoc query-type (assoc (intern docset-type) helm-dash-sql-queries))) pattern))
 
-(defun helm-dash-maybe-narrow-to-one-docset (pattern)
+(defun helm-dash-maybe-narrow-docsets (pattern)
   "Return a list of helm-dash-connections.
 If PATTERN starts with the name of a docset followed by a space, narrow the
  used connections to just that one.  We're looping on all connections, but it
  shouldn't be a problem as there won't be many."
-  (let ((conns (helm-dash-filter-connections)))
-    (or (cl-loop for x in conns
-                 if (string-prefix-p
-                     (concat (downcase (car x)) " ")
-                     (downcase pattern))
-                 return (list x))
-        conns)))
+  (let ((connections (helm-dash-filter-connections))
+        (f-word (car (split-string pattern " "))))
+    (or
+     (remove-if-not (lambda (x) (string-match f-word (car x)))
+              connections)
+     connections)))
 
 (defun helm-dash-sub-docset-name-in-pattern (pattern docset-name)
   "Remove from PATTERN the DOCSET-NAME if this includes it.
 If the search starts with the name of the docset, ignore it.
 Ex: This avoids searching for redis in redis unless you type 'redis redis'"
-  (replace-regexp-in-string
-   (format "^%s " (regexp-quote (downcase docset-name)))
-   ""
-   pattern))
+  (let ((f-word (car (split-string pattern " "))))
+    (if (string-match f-word docset-name)
+        (replace-regexp-in-string
+         (format "^%s " (regexp-quote f-word)) "" pattern)
+        pattern)))
 
 (defun helm-dash-search ()
   "Iterates every `helm-dash-connections' looking for the `helm-pattern'."
   (let ((full-res (list))
-        (connections (helm-dash-maybe-narrow-to-one-docset helm-pattern)))
+        (connections (helm-dash-maybe-narrow-docsets helm-pattern)))
 
     (dolist (docset connections)
       (let* ((docset-type (cl-caddr docset))

--- a/test/helm-dash-test.el
+++ b/test/helm-dash-test.el
@@ -25,9 +25,9 @@
 
 ;;; Code:
 
-;;;; helm-dash-maybe-narrow-to-one-docset
+;;;; helm-dash-maybe-narrow-docsets
 
-(ert-deftest helm-dash-maybe-narrow-to-one-docset-test/filtered ()
+(ert-deftest helm-dash-maybe-narrow-docsets-test/filtered ()
   "Should return a list with filtered connections."
   (let ((pattern "Go ")
         (helm-dash-docsets-path "/tmp/.docsets")
@@ -38,14 +38,14 @@
            ("C" "/tmp/.docsets/C.docset/Contents/Resources/docSet.dsidx" "DASH")
            ("C++" "/tmp/.docsets/C++.docset/Contents/Resources/docSet.dsidx" "DASH")
            ("CSS" "/tmp/.docsets/CSS.docset/Contents/Resources/docSet.dsidx" "ZDASH"))))
-    (should (equal (helm-dash-maybe-narrow-to-one-docset pattern)
+    (should (equal (helm-dash-maybe-narrow-docsets pattern)
                    '(("Go" "/tmp/.docsets/Go.docset/Contents/Resources/docSet.dsidx" "DASH"))))
 
-    (should (equal "C" (caar (helm-dash-maybe-narrow-to-one-docset "C foo"))))
-    (should (equal "C++" (caar (helm-dash-maybe-narrow-to-one-docset "C++ foo"))))
-    (should (equal "C" (caar (helm-dash-maybe-narrow-to-one-docset "c foo"))))))
+    (should (equal "C" (caar (helm-dash-maybe-narrow-docsets "C foo"))))
+    (should (equal "C++" (caar (helm-dash-maybe-narrow-docsets "C++ foo"))))
+    (should (equal "C" (caar (helm-dash-maybe-narrow-docsets "c foo"))))))
 
-(ert-deftest helm-dash-maybe-narrow-to-one-docset-test/not-filtered ()
+(ert-deftest helm-dash-maybe-narrow-docsets-test/not-filtered ()
   "Should return all current connections because the pattern doesn't match with any connection."
   (let ((pattern "FOOOO ")
 	(helm-dash-docsets-path "/tmp/.docsets")
@@ -54,7 +54,7 @@
 	 '(("Redis" "/tmp/.docsets/Redis.docset/Contents/Resources/docSet.dsidx" "DASH")
 	   ("Go" "/tmp/.docsets/Go.docset/Contents/Resources/docSet.dsidx" "DASH")
 	   ("CSS" "/tmp/.docsets/CSS.docset/Contents/Resources/docSet.dsidx" "ZDASH"))))
-    (should (equal (helm-dash-maybe-narrow-to-one-docset pattern) helm-dash-connections))))
+    (should (equal (helm-dash-maybe-narrow-docsets pattern) helm-dash-connections))))
 
 
 ;;;; helm-dash-sub-docset-name-in-pattern


### PR DESCRIPTION
Ability to download user contributed docsets.  It uses kidd/dashes-to-dashes api as an adapter. In the future, probably official ones will go through there also.

The behaviour of the app should be the same, just call m-x helm-dash-install-user-docset. RET


@areina: we should  test it thoughfully before merge