### PR TITLE
Add display of errors from sqlite3 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ searching. Defaults to 3.
 Dash' docsets. Defaults to browse-url. For example, if you want to use eww to
 browse your docsets, you can do: `(setq helm-dash-browser-func 'eww)`.
 
+When `helm-dash-enable-debugging` is non-nil stderr from sqlite queries is
+captured and displayed in a buffer. The default value is `t`. Setting this
+to `nil` may speed up queries on some machines (capturing stderr requires
+the creation and deletion of a temporary file for each query).
+
+
 ## Sets of Docsets
 
 ### Common docsets

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -67,7 +67,7 @@ path.  You can use `expand-file-name' function for that."
 of docsets are active.  Between 0 and 3 is sane."
   :group 'helm-dash)
 
-(defcustom helm-dash-debugging-mode t
+(defcustom helm-dash-enable-debugging t
   "When non-nil capture stderr from sql commands and display in a
 buffer. Setting this to nil may speed up querys."
   :group 'helm-dash)
@@ -106,7 +106,7 @@ Suggested values are:
   "Run the sql command, parse the results and display errors"
   (helm-dash-parse-sql-results
    (with-output-to-string
-     (let ((error-file (when helm-dash-debugging-mode
+     (let ((error-file (when helm-dash-enable-debugging
                          (make-temp-file "helm-dash-errors-file"))))
        (call-process "sqlite3" nil (list standard-output error-file) nil
                      ;; args for sqlite3:

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -67,6 +67,11 @@ path.  You can use `expand-file-name' function for that."
 of docsets are active.  Between 0 and 3 is sane."
   :group 'helm-dash)
 
+(defcustom helm-dash-debugging-mode t
+  "When non-nil capture stderr from sql commands and display in a
+buffer. Setting this to nil may speed up querys."
+  :group 'helm-dash)
+
 (defvar helm-dash-common-docsets
   '() "List of Docsets to search active by default.")
 
@@ -101,7 +106,8 @@ Suggested values are:
   "Run the sql command, parse the results and display errors"
   (helm-dash-parse-sql-results
    (with-output-to-string
-     (let ((error-file (make-temp-file "helm-dash-errors-file")))
+     (let ((error-file (when helm-dash-debugging-mode
+                         (make-temp-file "helm-dash-errors-file"))))
        (call-process "sqlite3" nil (list standard-output error-file) nil
                      ;; args for sqlite3:
                      db-path sql)


### PR DESCRIPTION
Fixes #80.

stderr from sqlite3 is sent to a file, which is then displayed as a buffer if it contains any text after the command has finished. This is based on the `shell-command` function, which seems to be the only one which provides useful error handling (but `shell-command` is not general enough for us to use directly).

Additionally by using `call-process` instead of `call-process-shell-command` we get an error if the `sqlite3` command cannot be found (my comment below was wrong, I didn't reset the connections properly when I tested it).

Finally I thought that `helm-dash-sql` was getting a bit too complicated and messy after these changes, so I moved the parsing out into a separate function.