### PR TITLE
Handle whitespace in docset folder path

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -246,7 +246,7 @@ Report an error unless a valid docset is selected."
   (let ((docset-folder
          (helm-dash-docset-folder-name
           (shell-command-to-string
-           (format "tar xvf %s -C %s" (shell-quote-argument docset-tmp-path) (helm-dash-docsets-path))))))
+           (format "tar xvf %s -C %s" (shell-quote-argument docset-tmp-path) (shell-quote-argument (helm-dash-docsets-path)))))))
     (helm-dash-activate-docset docset-folder)
     (message (format
               "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."


### PR DESCRIPTION
Restore the `(shell-quote-argument (helm-dash-docsets-path))` from
79d4979a33eaa46e25fde87b4f0a332dff112fa9 that seems to have been lost in a
merge.