### PR TITLE
Try harder to find dash installed docsets

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -73,11 +73,14 @@ of docsets are active.  Between 0 and 3 is sane."
 
 (defun helm-dash-docset-path (docset)
   "Return the full path of the directory for DOCSET."
-  (let ((top-level (format "%s/%s.docset" (helm-dash-docsets-path) docset))
-        (nested (format "%s/%s/%s.docset" (helm-dash-docsets-path) docset docset)))
-    (if (file-directory-p top-level)
-        top-level
-      nested)))
+  (let* ((base (helm-dash-docsets-path))
+         (docdir (expand-file-name docset base)))
+    (cl-loop for dir in (list (format "%s/%s.docset" base docset)
+                              (format "%s/%s.docset" docdir docset)
+                              (when (file-directory-p docdir)
+                                (cl-first (directory-files docdir t "\\.docset\\'"))))
+             when (and dir (file-directory-p dir))
+             return dir)))
 
 (defun helm-dash-docset-db-path (docset)
   "Compose the path to sqlite DOCSET."
@@ -197,10 +200,12 @@ See here the reason: https://github.com/areina/helm-dash/issues/17.")
 (defun helm-dash-installed-docsets ()
   "Return a list of installed docsets."
   (let ((docset-path (helm-dash-docsets-path)))
-    (cl-loop for dir in (directory-files docset-path)
+    (cl-loop for dir in (directory-files docset-path nil "^[^.]")
              for full-path = (expand-file-name dir docset-path)
+             for subdir = (cl-first (directory-files full-path t "\\.docset\\'"))
              when (or (string-match-p "\\.docset\\'" dir)
-                      (file-directory-p (expand-file-name (format "%s.docset" dir) full-path)))
+                      (file-directory-p (expand-file-name (format "%s.docset" dir) full-path))
+                      (and subdir (file-directory-p subdir)))
              collecting (replace-regexp-in-string "\\.docset\\'" "" dir))))
 
 (defun helm-dash-read-docset (prompt choices)


### PR DESCRIPTION
The paths where dash itself installs the docsets is somewhat
unpredictable (#84) and can not be reliably determined from the docset
name/id alone. For example:
* Bootstrap_2 => Bootstrap_2/Bootstrap.docset
* Bootstrap_3 => Bootstrap_3/Bootstrap 3.docset
* Emacs_Lisp => Emacs_Lisp/Emacs Lisp.docset

Try harder to find them simply by looking inside the directory and
accepting the first *.docset directory present. The list of paths
searched is now:
* {name/id}.docset             -- helm-dash installation, probably
* {name/id}/{name/id}.docset   -- dash installation, e.g. Haskell
* {name/id}/*.docset           -- dash installation, e.g. Bootstrap_2