### PR TITLE
Customize candidates with `helm-dash-candidate-format`

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -40,6 +40,7 @@
 (require 'helm-multi-match)
 (require 'json)
 (require 'xml)
+(require 'format-spec)
 
 (defgroup helm-dash nil
   "Search Dash docsets using helm."
@@ -65,6 +66,14 @@ path.  You can use `expand-file-name' function for that."
   "Minimum length to start searching in docsets.
 0 facilitates discoverability, but may be a bit heavy when lots
 of docsets are active.  Between 0 and 3 is sane."
+  :group 'helm-dash)
+
+(defcustom helm-dash-candidate-format "%d %n (%t)"
+  "Format of the displayed candidates.
+Available formats are
+   %d - docset name
+   %n - name of the token
+   %t - type of the token"
   :group 'helm-dash)
 
 (defcustom helm-dash-enable-debugging t
@@ -376,7 +385,12 @@ Ex: This avoids searching for redis in redis unless you type 'redis redis'"
                             (helm-dash-sub-docset-name-in-pattern helm-pattern (car docset))))))
 
 (defun helm-dash--candidate (docset x)
-  (cons (format "%s %s" (car docset) (cadr x)) (list (car docset) x)))
+  (dbg docset x)
+  (cons (format-spec helm-dash-candidate-format
+		     (list (cons ?d (car docset))
+			   (cons ?n (cadr x))
+			   (cons ?t (car x))))
+	(list (car docset) x)))
 
 (defun helm-dash-result-url (docset-name filename &optional anchor)
   "Return the full, absolute URL to documentation: either a file:// URL joining


### PR DESCRIPTION
I would also like to display the type of the token. So adding a custom specification of the candidate display.   