### PR TITLE
Fixes unpacking if `temporary-file-directory` contains "~"

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -293,7 +293,9 @@ Report an error unless a valid docset is selected."
   (let ((docset-folder
          (helm-dash-docset-folder-name
           (shell-command-to-string
-           (format "tar xvf %s -C %s" (shell-quote-argument docset-tmp-path) (shell-quote-argument (helm-dash-docsets-path)))))))
+           (format "tar xvf %s -C %s"
+                   (shell-quote-argument (expand-file-name docset-tmp-path))
+                   (shell-quote-argument (helm-dash-docsets-path)))))))
     (helm-dash-activate-docset docset-folder)
     (message (format
               "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."


### PR DESCRIPTION
In my setup `temporary-file-directory = "~/.emacs.d/backup"` and it cause error during unpacking.
This small patch should fix this.