### PR TITLE
Candidates-process is called every keypress.

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -468,14 +468,15 @@ Get required params to call `helm-dash-result-url' from SEARCH-RESULT."
 (defun helm-dash-build-source (docset)
   "Build a Helm source for DOCSET."
   (lexical-let ((docset docset))
-   (helm-build-async-source (car docset)
-     :action-transformer #'helm-dash-actions
-     :candidates-process (lambda ()
-                           (cl-loop for row in (helm-dash--run-query docset)
-                                    collect (helm-dash--candidate docset row)))
-     :delayed t
-     :persistent-help "View doc"
-     :requires-pattern helm-dash-min-length)))
+    (helm-build-sync-source (car docset)
+      :action-transformer #'helm-dash-actions
+      :candidates (lambda ()
+		    (cl-loop for row in (helm-dash--run-query docset)
+			     collect (helm-dash--candidate docset row)))
+      :delayed t
+      :volatile t
+      :persistent-help "View doc"
+      :requires-pattern helm-dash-min-length)))
 
 (defun helm-dash-sources--narrowed-docsets ()
   "Return a list of Helm sources for narrowed docsets.

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -467,13 +467,15 @@ Get required params to call `helm-dash-result-url' from SEARCH-RESULT."
 
 (defun helm-dash-build-source (docset)
   "Build a Helm source for DOCSET."
-  (helm-build-async-source (car docset)
-    :action-transformer #'helm-dash-actions
-    :candidates-process (cl-loop for row in (helm-dash--run-query docset)
-				 collect (helm-dash--candidate docset row))
-    :delayed t
-    :persistent-help "View doc"
-    :requires-pattern helm-dash-min-length))
+  (lexical-let ((docset docset))
+   (helm-build-async-source (car docset)
+     :action-transformer #'helm-dash-actions
+     :candidates-process (lambda ()
+                           (cl-loop for row in (helm-dash--run-query docset)
+                                    collect (helm-dash--candidate docset row)))
+     :delayed t
+     :persistent-help "View doc"
+     :requires-pattern helm-dash-min-length)))
 
 (defun helm-dash-sources--narrowed-docsets ()
   "Return a list of Helm sources for narrowed docsets.


### PR DESCRIPTION
In db04dd562526163131, we introduced a bug that searched the db's just
on init, not following minimal-length or recalculating results. This
commit fixes it.

Fixes #124