### PR TITLE
Fix issue #67 (no results in first call to helm-dash)

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -165,9 +165,8 @@ Suggested values are:
 
 (defun helm-dash-buffer-local-docsets ()
   "Get the docsets configured for the current buffer."
-  (with-helm-current-buffer
-    (or (and (boundp 'helm-dash-docsets) helm-dash-docsets)
-	'())))
+  (or (and (boundp 'helm-dash-docsets) helm-dash-docsets)
+      '()))
 
 (defun helm-dash-create-common-connections ()
   "Create connections to sqlite docsets for common docsets."

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -481,7 +481,6 @@ Get required params to call `helm-dash-result-url' from SEARCH-RESULT."
       :candidates (lambda ()
 		    (cl-loop for row in (helm-dash--run-query docset)
 			     collect (helm-dash--candidate docset row)))
-      :delayed t
       :volatile t
       :persistent-help "View doc"
       :requires-pattern helm-dash-min-length)))

--- a/test/helm-dash-test.el
+++ b/test/helm-dash-test.el
@@ -126,6 +126,28 @@
     (should (equal'("Clojure" "Redis" "Go" "CSS") helm-dash-common-docsets))
     (should (equal nil helm-dash-connections))))
 
+;; helm-dash-buffer-local-docsets
+
+(ert-deftest helm-dash-buffer-local-docsets-narrowing ()
+  (let ((c-buffer nil)
+        (helm-dash-connections
+         '(("Go" "/tmp/.docsets/Go.docset/Contents/Resources/docSet.dsidx" "DASH")
+           ("C" "/tmp/.docsets/C.docset/Contents/Resources/docSet.dsidx" "DASH")
+           ("CSS" "/tmp/.docsets/CSS.docset/Contents/Resources/docSet.dsidx" "ZDASH"))))
+    (with-temp-buffer
+      (setq c-buffer (current-buffer))
+      (setq-local helm-dash-docsets (list "C"))
+
+      (with-temp-buffer
+        (setq-local helm-dash-docsets (list "Go"))
+        (should (equal (helm-dash-maybe-narrow-docsets "*")
+                       '(("Go" "/tmp/.docsets/Go.docset/Contents/Resources/docSet.dsidx" "DASH"))))
+
+        (with-current-buffer c-buffer
+          (should (equal (helm-dash-maybe-narrow-docsets "*")
+                         '(("C" "/tmp/.docsets/C.docset/Contents/Resources/docSet.dsidx" "DASH"))))
+          )))))
+
 (provide 'helm-dash-test)
 
 ;;; helm-dash-test ends here


### PR DESCRIPTION
Details in the commit message.

Also removed an option from the call to `helm-build-sync-source` because it's deprecated and the latest version of helm opens an error window every time you run `helm-dash` telling you about it. I don't really understand what the `:delayed` is/was supposed to do, but helm-dash still "works-on-my-machine"...