### PR TITLE
Fixed README.md typo for the default helm-dash-docsets-path value

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The next call to `helm-dash` will recreate them.
 
 ## Variables to customize
 
-`helm-dash-docsets-path` is the prefix for your docsets. Defaults to ~/.docset
+`helm-dash-docsets-path` is the prefix for your docsets. Defaults to ~/.docsets
 
 `helm-dash-min-length` tells helm-dash from which length to start
 searching. Defaults to 3.


### PR DESCRIPTION
Hi, was setting this up today and noticed this typo for the default value of `helm-dash-docsets-path` in the readme.