### PR TITLE
Fix opening docs in eww in Windows (again)

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -458,7 +458,7 @@ candidate opts."
 	(list (car docset) row)))
 
 (defun helm-dash-result-url (docset-name filename &optional anchor)
-  "Return the full, absolute URL to documentation: either a file:// URL joining
+  "Return the full, absolute URL to documentation: either a file:/// URL joining
 DOCSET-NAME, FILENAME & ANCHOR with sanitization of spaces or a http(s):// URL
 formed as-is if FILENAME is a full HTTP(S) URL."
   (let ((path (format "%s%s" filename (if anchor (format "#%s" anchor) ""))))
@@ -468,7 +468,7 @@ formed as-is if FILENAME is a full HTTP(S) URL."
        " "
        "%20"
        (concat
-	"file://"
+	"file:///"
 	(expand-file-name "Contents/Resources/Documents/" (helm-dash-docset-path docset-name))
 	path)))))
 


### PR DESCRIPTION
With the `file://` prefix, eww thinks that you're trying to open an FTP connection. However, with `file:///` (note the additional slash), everything works fine.

Same patch as ccea7c53caa51a37a3829e333ed745f6709a26ea, previously seen in #58. Was broken by db04dd5625261631311d68108a057a1d32fc69a4.