### PR TITLE
Remove <dash_entry_.*> from documentation urls

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -458,10 +458,11 @@ candidate opts."
 	(list (car docset) row)))
 
 (defun helm-dash-result-url (docset-name filename &optional anchor)
-  "Return the full, absolute URL to documentation: either a file:/// URL joining
-DOCSET-NAME, FILENAME & ANCHOR with sanitization of spaces or a http(s):// URL
-formed as-is if FILENAME is a full HTTP(S) URL."
-  (let ((path (format "%s%s" filename (if anchor (format "#%s" anchor) ""))))
+  "Return the full, absolute URL to documentation.
+Either a file:/// URL joining DOCSET-NAME, FILENAME & ANCHOR with sanitization
+ of spaces or a http(s):// URL formed as-is if FILENAME is a full HTTP(S) URL."
+  (let* ((clean-filename (replace-regexp-in-string "<dash_entry_.*>" "" filename))
+	 (path (format "%s%s" clean-filename (if anchor (format "#%s" anchor) ""))))
     (if (string-match-p "^https?://" path)
 	path
       (replace-regexp-in-string

--- a/test/helm-dash-test.el
+++ b/test/helm-dash-test.el
@@ -87,6 +87,10 @@
   (should (string-match-p "Documents/three#anchor$"
                           (helm-dash-result-url "Redis" "three#anchor"))))
 
+(ert-deftest helm-dash-result-url/remove-dash-entry-tag-from-url ()
+  (should (string-match-p "Documents/three#anchor$"
+                          (helm-dash-result-url "Python 3" "three<dash_entry_menuDescription=android.provider.ContactsContract.CommonDataKinds.Website>" "anchor"))))
+
 ;;;; helm-dash-docsets-path
 
 (ert-deftest helm-dash-docsets-path-test/relative-path ()


### PR DESCRIPTION
These kind of tags were added recently in Dash docsets and aren't useful for
us, so we can remove them directly from the url.

Fixes #145