### PR TITLE
Fix helm-dash-at-point when no symbol at point

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -585,7 +585,7 @@ If INPUT-PATTERN is non-nil, use it as an initial input in helm search."
   "Bring up a `helm-dash' search interface with symbol at point."
   (interactive)
   (helm-dash
-   (substring-no-properties (thing-at-point 'symbol))))
+   (substring-no-properties (or (thing-at-point 'symbol) ""))))
 
 
 (provide 'helm-dash)


### PR DESCRIPTION
When point is on a space, blank line, punctuation etc. use a blank string as input instead to `nil` to avoid "Wrong type argument: stringp, nil" from `substring-no-properties`.

The problem was probably introduced recently in b7fbf789b83e290885e506e887f6ed9c5b858423.