### PR TITLE
Refactor install docset functions

### DIFF
--- a/helm-dash.el
+++ b/helm-dash.el
@@ -349,7 +349,7 @@ The Argument FEED-PATH should be a string with the path of the xml file."
   "Asynchronously download docset with specified DOCSET-NAME and move its stuff to docsets-path."
   (interactive (list (helm-dash-read-docset "Install docset" (helm-dash-official-docsets))))
   (when (helm-dash--ensure-created-docsets-path (helm-dash-docsets-path))
-    (message (concat "The docset \"" docset-name "\" will now be installed."))
+    (message "The docset \"%s\" will now be installed." docset-name)
     (let ((docsets-path helm-dash-docsets-path)
           (docsets-url helm-dash-docsets-url))
       (async-start ; First async call gets the docset meta data
@@ -362,9 +362,8 @@ The Argument FEED-PATH should be a string with the path of the xml file."
          (when (string= docset-folder "nil")
            (user-error "Error installing docset \"%s\"" docset-name))
          (helm-dash-activate-docset docset-folder)
-         (message (format
-                   "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."
-                   docset-folder)))))))
+         (message "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."
+                   docset-folder))))))
 
 ;;;###autoload
 (defun helm-dash-async-install-docset-from-file (docset-tmp-path)
@@ -378,9 +377,8 @@ The Argument FEED-PATH should be a string with the path of the xml file."
        (helm-dash-extract-docset docset-tar-path docsets-path))
      (lambda (docset-folder)
        (helm-dash-activate-docset docset-folder)
-       (message (format
-                 "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."
-                 docset-folder))))))
+       (message "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."
+                 docset-folder)))))
 
 (defalias 'helm-dash-update-docset 'helm-dash-install-docset)
 

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -399,7 +399,7 @@ The Argument FEED-PATH should be a string with the path of the xml file."
 (defun helm-dash-ensure-docset-installed (docset)
   "Install DOCSET if it is not currently installed."
   (unless (helm-dash-docset-installed-p docset)
-    (helm-dash-install-docset docset)))
+    (helm-dash-async-install-docset docset)))
 
 (defvar helm-dash-sql-queries
   '((DASH . (lambda (pattern)

--- a/helm-dash.el
+++ b/helm-dash.el
@@ -299,6 +299,15 @@ If doesn't exist, it asks to create it."
   (when (helm-dash--ensure-created-docsets-path (helm-dash-docsets-path))
     (helm-dash--install-docset (car (assoc-default docset-name (helm-dash-unofficial-docsets))) docset-name)))
 
+(defmacro helm-dash-extract-docset-into (docset-archive docsets-path docset-name)
+  "Extract DOCSET-ARCHIVE into DOCSETS-PATH/DOCSET-NAME, removing top directory."
+  `(let ((docset-dir (concat (file-name-as-directory docsets-path) docset-name ".docset")))
+     (mkdir docset-dir t)
+     (shell-command (format "tar xvf %s -C %s --strip-components=1"
+                            (shell-quote-argument (expand-file-name ,docset-archive))
+                            (shell-quote-argument (expand-file-name docset-dir))))
+     docset-name))
+
 (defmacro helm-dash-extract-docset (docset-archive docsets-path)
   "Extract DOCSET-ARCHIVE to DOCSETS-PATH."
   `(let* ((tar-output (shell-command-to-string
@@ -361,9 +370,9 @@ The Argument FEED-PATH should be a string with the path of the xml file."
        (lambda (docset-folder)
          (when (string= docset-folder "nil")
            (user-error "Error installing docset \"%s\"" docset-name))
-         (helm-dash-activate-docset docset-folder)
+         (helm-dash-activate-docset docset-name)
          (message "Docset installed. Add \"%s\" to helm-dash-common-docsets or helm-dash-docsets."
-                   docset-folder))))))
+                  docset-name))))))
 
 ;;;###autoload
 (defun helm-dash-async-install-docset-from-file (docset-tmp-path)
@@ -384,7 +393,7 @@ The Argument FEED-PATH should be a string with the path of the xml file."
 
 (defun helm-dash-docset-installed-p (docset)
   "Return true if DOCSET is installed."
-  (member (replace-regexp-in-string "_" " " docset) (helm-dash-installed-docsets)))
+  (member docset (helm-dash-installed-docsets)))
 
 ;;;###autoload
 (defun helm-dash-ensure-docset-installed (docset)


### PR DESCRIPTION
As of today, they are docsets named for example Ruby_on_Rails_4 or Ruby_on_Rails_5 that contains a top level directory in their archived named "Ruby on Rails". This causes multiple problems.

1. When using helm-dash-ensure-package-installed, helm-dash checks for Ruby_on_Rails_4 in the docsets path but it does not find it as it is named after the top directory in the archive, "Ruby on Rails".

2. It's not possible to install both Ruby_on_Rails_4 and Ruby_on_Rails_5 docsets.

To fix this, this pull requests refactors the code for helm-dash-install-docset and helm-dash-async-install-docset to share more codes by making the synchronous function call the asynchronous function. To simplify the asynchronous function, macros are used as they are expanded at compile time and so can be used in the async-start lambda. With this in place, the install function is made to strip the top level directory of a docset tarball and install in a directory named after the original docset name. The helm-dash-docset-installedp function is updated to check for the right name.

The helm-dash-ensure-docset-installed function is also changed to use the asynchronous install method to avoid blocking the Emacs initialization process.